### PR TITLE
The 'add to homescreen' should only show up on mobile devices

### DIFF
--- a/packages/chat/app/components/InstallPWA.tsx
+++ b/packages/chat/app/components/InstallPWA.tsx
@@ -13,7 +13,7 @@ export function InstallPWA() {
   const [isInstallable, setIsInstallable] = useState(false);
 
   useEffect(() => {
-    if (Platform.OS !== 'web') return;
+    if (Platform.OS !== 'ios' && Platform.OS !== 'android') return;
 
     const handleBeforeInstallPrompt = (e: Event) => {
       e.preventDefault();
@@ -44,7 +44,7 @@ export function InstallPWA() {
     setDeferredPrompt(null);
   };
 
-  if (!isInstallable || Platform.OS !== 'web') return null;
+  if (!isInstallable || (Platform.OS !== 'ios' && Platform.OS !== 'android')) return null;
 
   return (
     <Button 

--- a/packages/chat/app/components/WelcomeModal.tsx
+++ b/packages/chat/app/components/WelcomeModal.tsx
@@ -137,7 +137,7 @@ export function WelcomeModal() {
                     </Text>
                 </Text>
 
-                {Platform.OS === "web" && (
+                {(Platform.OS === "ios" || Platform.OS === "android") && (
                     <Text style={styles.content as any}>
                         💡 Pro tip: Install Orbiting as an app on your device
                         for the best experience!
@@ -148,7 +148,7 @@ export function WelcomeModal() {
                     <Button mode="contained" onPress={hideModal}>
                         Get Started
                     </Button>
-                    {Platform.OS === "web" && <InstallPWA />}
+                    {(Platform.OS === "ios" || Platform.OS === "android") && <InstallPWA />}
                 </View>
             </Modal>
         </Portal>


### PR DESCRIPTION
Update the "add to homescreen" button to only show up on mobile devices.

* Modify `InstallPWA.tsx` to check for `Platform.OS` being either 'ios' or 'android' instead of 'web'.
* Update `WelcomeModal.tsx` to conditionally render the "add to homescreen" button only on mobile devices by checking for `Platform.OS` being either 'ios' or 'android'.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/harperreed/orbiting/pull/66?shareId=772d3353-8191-4cd7-85f2-1d1d2663188a).