### PR TITLE
Add open graph metadata

### DIFF
--- a/packages/chat/app/+html.tsx
+++ b/packages/chat/app/+html.tsx
@@ -33,6 +33,9 @@ export default function Root({ children }: PropsWithChildren) {
                 <ScrollViewStyleReset />
 
                 {/* Add any additional <head> elements that you want globally available on web... */}
+                <meta property="og:image" content="https://orbiting.com/imgs/og.png" />
+                <meta property="og:url" content={typeof window !== 'undefined' ? window.location.href : ''} />
+                <meta property="og:type" content="website" />
             </head>
             <body>{children}</body>
         </html>

--- a/packages/chat/app/_layout.tsx
+++ b/packages/chat/app/_layout.tsx
@@ -17,24 +17,49 @@ function AppContent() {
 
   useEffect(() => {
     let title = 'Orbiting';
-    
+    let ogTitle = 'Orbiting';
+    let ogDescription = 'A text display app';
+    let ogImage = 'https://orbiting.com/imgs/og.png';
+
     switch (pathname) {
       case '/history':
         title = `${t('history')} | Orbiting`;
+        ogTitle = `${t('history')} | Orbiting`;
         break;
       case '/settings':
         title = `${t('settings')} | Orbiting`;
+        ogTitle = `${t('settings')} | Orbiting`;
         break;
       case '/help':
         title = `${t('help')} | Orbiting`;
+        ogTitle = `${t('help')} | Orbiting`;
         break;
       case '/about':
         title = `${t('about')} | Orbiting`;
+        ogTitle = `${t('about')} | Orbiting`;
         break;
     }
 
     if (typeof document !== 'undefined') {
       document.title = title;
+
+      const metaTags = [
+        { property: 'og:title', content: ogTitle },
+        { property: 'og:description', content: ogDescription },
+        { property: 'og:image', content: ogImage },
+        { property: 'og:url', content: window.location.href },
+        { property: 'og:type', content: 'website' }
+      ];
+
+      metaTags.forEach(({ property, content }) => {
+        let metaTag = document.querySelector(`meta[property="${property}"]`);
+        if (!metaTag) {
+          metaTag = document.createElement('meta');
+          metaTag.setAttribute('property', property);
+          document.head.appendChild(metaTag);
+        }
+        metaTag.setAttribute('content', content);
+      });
     }
   }, [pathname, t]);
   

--- a/packages/chat/app/index.tsx
+++ b/packages/chat/app/index.tsx
@@ -17,5 +17,25 @@ export default function Index() {
     }
   }, []);
 
+  useEffect(() => {
+    if (Platform.OS === 'web' && typeof document !== 'undefined') {
+      const metaTags = [
+        { property: 'og:title', content: 'Orbiting' },
+        { property: 'og:description', content: 'A text display app' },
+        { property: 'og:image', content: 'https://orbiting.com/imgs/og.png' }
+      ];
+
+      metaTags.forEach(({ property, content }) => {
+        let metaTag = document.querySelector(`meta[property="${property}"]`);
+        if (!metaTag) {
+          metaTag = document.createElement('meta');
+          metaTag.setAttribute('property', property);
+          document.head.appendChild(metaTag);
+        }
+        metaTag.setAttribute('content', content);
+      });
+    }
+  }, []);
+
   return <HomeScreen />;
 }


### PR DESCRIPTION
Fixes #57

Add Open Graph and sharing metadata to web pages.

* Modify `packages/chat/app/+html.tsx` to include `og:image`, `og:url`, and `og:type` meta tags.
* Modify `packages/chat/app/index.tsx` to include `og:title`, `og:description`, and `og:image` meta tags.
* Modify `packages/chat/app/_layout.tsx` to dynamically set `og:title`, `og:description`, `og:image`, `og:url`, and `og:type` meta tags based on the current page.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/harperreed/orbiting/pull/75?shareId=0c4ba441-813a-4f2c-8c49-c787cb49c522).